### PR TITLE
Fixes for Mob Farms V2

### DIFF
--- a/purpur.yml
+++ b/purpur.yml
@@ -14,7 +14,7 @@ settings:
   server-mod-name: Purpur
   use-alternate-keepalive: false
   dont-send-useless-entity-packets: true
-  lagging-threshold: 19.9
+  lagging-threshold: 19.5
   allow-water-placement-in-the-end: true
   tps-catchup: true
   disable-give-dropping: false
@@ -375,8 +375,8 @@ world-settings:
       villager:
         ridable: false
         ridable-in-water: false
-        brain-ticks: 10
-        use-brain-ticks-only-when-lagging: false
+        brain-ticks: 4
+        use-brain-ticks-only-when-lagging: true
         follow-emerald-blocks: false
         can-be-leashed: true
         can-breed: true
@@ -1044,7 +1044,7 @@ world-settings:
       furnace:
         use-lava-from-underneath: false
       end_portal:
-        safe-teleporting: true
+        safe-teleporting: false
       blue_ice:
         allow-snow-formation: true
         allow-mob-spawns: true

--- a/spigot.yml
+++ b/spigot.yml
@@ -92,7 +92,7 @@ world-settings:
     hanging-tick-frequency: 100
     zombie-aggressive-towards-villager: true
     nerf-spawner-mobs: true
-    mob-spawn-range: 6
+    mob-spawn-range: 8
     end-portal-sound-radius: 0
     max-entity-collisions: 2
     merge-radius:


### PR DESCRIPTION
mob-spawn-range: set to 8 (from 6)
>This value should always be set to a maximum of (View Distance – 1) with a minimum of 3 as any entity fall outside of the view distance and the bordering chunk wont be ticked anyway.